### PR TITLE
specify encoding utf8 to open()

### DIFF
--- a/cvim_server.py
+++ b/cvim_server.py
@@ -26,7 +26,7 @@ def edit_file(content):
     os.close(fd)
     subprocess.Popen(shlex.split(VIM_COMMAND) + [fn]).wait()
     text = None
-    with open(fn, 'r') as f:
+    with open(fn, 'r', encoding='utf8') as f:
         text = f.read()
     os.unlink(fn)
     return text


### PR DESCRIPTION
This prevents 'UnicodeDecodeError: 'charmap' codec can't decode byte [...]'